### PR TITLE
Use ECR registry to avoid rate-limiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/planetscale/ghcommit:v0.1.6 AS ghcommit
 
-FROM alpine:3.18 AS base
+FROM public.ecr.aws/docker/library/alpine:3.18 AS base
 
 COPY --from=ghcommit /ghcommit /usr/bin/ghcommit
 


### PR DESCRIPTION
We're experiencing this error for builds:

```
429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

Instead of using docker-hub, let's use the AWS registry to avoid getting rate-limited.