### PR TITLE
docker: switch to wolfi base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/planetscale/ghcommit:v0.1.10 AS ghcommit
 
-FROM public.ecr.aws/docker/library/alpine:3.18 AS base
+FROM pscale.dev/wolfi-prod/base:latest AS base
 
 COPY --from=ghcommit /ghcommit /usr/bin/ghcommit
 


### PR DESCRIPTION
Alpine's apk repo is occassionally throttling the `apk add`. Let's use our wolfi base images instead.

longer term we should probably make a new
`pscale.dev/wolfi-prod/ghcommit` image containing ghcommit + bash + git, or at least a `ghcommit-base` image that contains just bash+git, since we don't have an APK package for ghcommit at the moment, and not sure if it's worth making one yet.