### PR TITLE
docs: Update checkout step in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      # Include the pull request ref in the checkout action to prevent merge commit
+      # https://github.com/actions/checkout?tab=readme-ov-file#checkout-pull-request-head-commit-instead-of-merge-commit
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Run steps that make changes to the local repo here.
 


### PR DESCRIPTION
This update illustrates how  to check out the pull request head commit in the example workflow.

You may want to add this because, without it, the checkout step fetches the pull request's *merge branch* so, when the action runs, it creates a merge commit and then another commit for updated files in your pull request.

The checkout action example is here: <https://github.com/actions/checkout?tab=readme-ov-file#checkout-pull-request-head-commit-instead-of-merge-commit>