### PR TITLE
feat: provide the commit information as output

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,12 @@ inputs:
     required: false
     default: "."
 
+outputs:
+  commit-url:
+    description: The URL of the created commit.
+  commit-hash:
+    description: The hash of the created commit.
+
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,4 +74,14 @@ ghcommit_args+=("${deletes[@]/#/--delete=}")
 
 [[ -n "${DEBUG:-}" ]] && echo "ghcommit args: '${ghcommit_args[*]}'"
 
-ghcommit "${ghcommit_args[@]}"
+output=$(ghcommit "${ghcommit_args[@]}" 2>&1) || {
+  # Show the output on error. This is needed since the exit immediately flag is set.
+  echo "$output" 1>&2;
+  exit 1
+}
+echo "$output"
+
+commit_url=$(echo "$output" | grep "Success. New commit:" | awk '{print $NF}')
+commit_hash=$(echo "$commit_url" | awk -F '/' '{print $NF}')
+echo "commit-url=$commit_url" >> "$GITHUB_OUTPUT"
+echo "commit-hash=$commit_hash" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR introduces two output variables: `commit-url` and `commit-hash` which provides the information about the created commit for additional steps in the workflow.