### PR TITLE
force release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ghcr.io/planetscale/ghcommit:v0.1.48@sha256:9ebf836e2bdbb88e536984312a9083af8c95487ad2b59a1d830672bf4d9053ea AS ghcommit
 
+# hadolint ignore=DL3007
 FROM pscale.dev/wolfi-prod/base:latest AS base
 
 COPY --from=ghcommit /ghcommit /usr/bin/ghcommit
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
         bash \
         git


### PR DESCRIPTION
the 'release' step in the GHA workflow has a filter to only cut new releases on certain files changing. the previous PR only updated the tests so a new release was not cut, but we need to cut a new release to get the recent GITHUB_OUTPUT feature out