### PR TITLE
[minor] optimize docker pulls when action is executed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - "*"
+      - '**'
 
 jobs:
   test:
@@ -13,40 +13,3 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - run: make lint
       - run: make test
-
-  release:
-    needs: [test]
-    # only create a release on main builds:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code with full history (unshallow)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      # only generate a new release if certain files change:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        with:
-          filters: |
-            app:
-              - 'action.yaml'
-              - '**.sh'
-              - 'Dockerfile'
-
-      - name: install autotag binary
-        if: steps.filter.outputs.app == 'true'
-        run: |
-          curl -sL https://git.io/autotag-install | sudo sh -s -- -b /usr/local/bin
-
-      - name: increment tag and create release
-        if: steps.filter.outputs.app == 'true'
-        run: |
-          set -eou pipefail
-
-          new_version=$(autotag -vn)
-          gh release create v"${new_version}" --target main --title "v${new_version}" --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,94 @@
+name: release
+
+# release process:
+#
+# on main branch merge:
+# 1. Calculate next semantic version tag (autotag)
+# 2. Build and push Dockerfile.base (ghcr.io/planetscale/ghcommit-action)
+# 3. Update version tag in Dockerfile, commit change
+# 4. Create GitHub Release for the new version
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - action.yaml
+      - '**.sh'
+      - Dockerfile
+      - Dockerfile.base
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && !contains(toJson(github.event.commits), '[ci skip]') && !contains(toJson(github.event.commits), '[skip ci]')
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - run: make lint
+      - run: make test
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [test]
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: checkout code with full history (unshallow)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Calculate new version with autotag
+        run: |
+          set -xeou pipefail
+
+          curl -sL https://git.io/autotag-install | sh -s -- -b "${RUNNER_TEMP}/bin"
+          new_version=$(${RUNNER_TEMP}/bin/autotag -n -b joem/optimize-image-pull)
+          echo "new_version=$new_version" >> $GITHUB_ENV
+
+      - name: login to ghcr.io
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # setup qemu and buildx for cross-builds (arm64)
+      - name: Set up QEMU (for arm64 builds)
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
+
+      - name: Build and push Dockerfile.base (ghcr.io/planetscale/ghcommit-action)
+        run: |
+          # build and push a multi-arch image:
+          image="ghcr.io/planetscale/ghcommit-action:v${new_version}"
+          docker buildx build \
+            -f Dockerfile.base \
+            --platform linux/amd64,linux/arm64 \
+            --output type=image,name=$image,oci-mediatypes=true,compression=zstd,push=true \
+            .
+
+      - name: Update image version in Dockerfile
+        run: |
+          sed -i'' -Ee "s/ghcommit-action:v(.*)/ghcommit-action:v${new_version}/" Dockerfile
+
+      - name: Commit changes
+        uses: planetscale/ghcommit-action@c7915d6c18d5ce4eb42b0eff3f10a29fe0766e4c # v0.1.44
+        with:
+          commit_message: "🤖 Bump version in Dockerfile"
+          repo: ${{ github.repository }}
+          branch: ${{ github.head_ref || github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create GitHub Release
+        run: |
+            gh release create "v${new_version}" --target main --title "v${new_version}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -17,6 +17,11 @@ jobs:
           git mv README.md README.md.old
           echo 'test' >new.file
 
+      # - build temp docker image
+      # - mutate version in Dockerfile to use the temp image
+      # - run plugin
+      # - can we reset the branch after the test?
+
       - name: ghcommit
         uses: ./
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,1 @@
-FROM ghcr.io/planetscale/ghcommit:v0.1.51@sha256:eb0fa7df39e99d74cb14adf98b9d255eeef45577698eadc6eef546f278256eb1 AS ghcommit
-
-# hadolint ignore=DL3007
-FROM pscale.dev/wolfi-prod/base:latest AS base
-
-COPY --from=ghcommit /ghcommit /usr/bin/ghcommit
-
-# hadolint ignore=DL3018
-RUN apk add --no-cache \
-        bash \
-        git
-
-COPY entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+FROM ghcr.io/planetscale/ghcommit-action:v0.0.0

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,15 @@
+FROM ghcr.io/planetscale/ghcommit:v0.1.51@sha256:eb0fa7df39e99d74cb14adf98b9d255eeef45577698eadc6eef546f278256eb1 AS ghcommit
+
+# hadolint ignore=DL3007
+FROM pscale.dev/wolfi-prod/base:latest AS base
+
+COPY --from=ghcommit /ghcommit /usr/bin/ghcommit
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+        bash \
+        git
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
When a docker-based github-action is run in a workflow, github pulls the repo and then builds an image from the `Dockerfile` every time. In our case this involves downloading and installing some apk packages. We can pre-bake this image and save some bandwidth and time.

1. Moved the `release` job out of the `ci.yaml` workflow and into a new `release.yaml` GHA workflow. Release runs only on main merges.
2. New `Dockerfile.base` contains all of the apk dependencies. It creates the runtime image
3. Release workflow builds `Dockerfile.base` and pushes to `ghcr.io/planetscale/ghcommit-action:v${new_version}`. autotag is still used to calculate the $new_version.
4. Release workflow updates the version in `Dockerfile` and commits back to the main branch.

The runtime `Dockerfile` is now a 1-liner referencing `ghcr.io/planetscale/ghcommit-action:v${new_version}'`

> This commit contains `[minor]` in the commit message which will trigger autotag to increment the minor version. This will be the start of v0.2.0.
