### PR TITLE
renovate: ignore runtime Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
     "github>planetscale/renovate-config",
     "github>planetscale/renovate-config:weeklyBatchMinorPatchDigest"
   ],
+  "ignorePaths": [
+    "Dockerfile"
+  ]
   "packageRules": [
     {
       "description": "Don't pin base image, we do not want its weekly updates.",


### PR DESCRIPTION
with the new release process that pre-builds a full image for faster runtimes and less bandwidth the `Dockerfile` is updated by the github action to use the latest version tag. Immediately after the release workflow finishes renovate will come along and update it again with a sha pin. We don't want this. Ideally the release workflow would also pin the SHA but for now let's just ignore this file and handle that at a later time.