### PR TITLE
chore: bump ghcommit to v0.1.55

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ghcr.io/planetscale/ghcommit:v0.1.51@sha256:eb0fa7df39e99d74cb14adf98b9d255eeef45577698eadc6eef546f278256eb1 AS ghcommit
+FROM ghcr.io/planetscale/ghcommit:v0.1.55@sha256:1e619715b0b8b4f80571ae0c1afaebc2329f5eb5514c878303dbe43ce0944563 AS ghcommit
 
 # hadolint ignore=DL3007
 FROM pscale.dev/wolfi-prod/base:latest AS base


### PR DESCRIPTION
This PR updates the dockerfile.base ghcommit version to v0.1.55.

Looks like the renovate setup stopped working for ghcommit with the PR to v0.1.51 (#73).