### PR TITLE
renovate: fix ignorePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     "github>planetscale/renovate-config:weeklyBatchMinorPatchDigest"
   ],
   "ignorePaths": [
-    "Dockerfile"
+    "**/Dockerfile"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
the intent is to ignore `Dockerfile` while still providing updates to `Dockerfile.base`, but this was not working and renovate was ignoring both

in my local testing this seems to have fixed that issue

reported in https://github.com/planetscale/ghcommit-action/pull/86