### PR TITLE
fix: handle untracked files 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,10 @@ while IFS= read -r -d $'\0' line; do
   # handle adds (A), modifications (M), and type changes (T):
   [[ "$tree_status" =~ A|M|T || "$index_status" =~ A|M|T ]] && adds+=("$filename")
 
+  # handle untracked files (??):
+  # https://github.com/planetscale/ghcommit-action/issues/43#issuecomment-1950986790
+  [[ "$tree_status" == "?" && "$index_status" == "?" ]] && adds+=("$filename")
+
   # handle deletes (D):
   [[ "$tree_status" =~ D || "$index_status" =~ D ]] && deletes+=("$filename")
 

--- a/tests/fixtures/git-status.out-2
+++ b/tests/fixtures/git-status.out-2
@@ -1,0 +1,3 @@
+?? untracked.txt
+?? new-file.md
+ M modified.txt


### PR DESCRIPTION
Fixes #43

## Description

- Untracked files (`??` status) were not being detected, causing "No changes detected" when only new files existed.
- Adds handling for untracked files and a corresponding test case.