### PR TITLE
feat: add optional repository input

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ Example showing all options:
           branch: ${{ github.head_ref || github.ref_name }}
           empty: true
           file_pattern: '*.txt *.md *.json *.hcl'
+          repository: 'path/to/subdir'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
+
+The `repository` input is optional. When set, it must be a relative path under
+`$GITHUB_WORKSPACE` pointing to the git repository to operate on. Defaults to
+the root of the repository (`.`).
 
 See [`action.yaml`](./action.yaml) for current list of supported inputs.
 

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,10 @@ inputs:
     description: File pattern used for `git add`. For example `src/*.js`
     required: false
     default: "."
+  repository:
+    description: Relative file path under $GITHUB_WORKSPACE to the git repository. Defaults to the root of the repository (`.`).
+    required: false
+    default: "."
 
 outputs:
   commit-url:
@@ -39,3 +43,4 @@ runs:
     - ${{ inputs.branch }}
     - ${{ inputs.empty }}
     - ${{ inputs.file_pattern }}
+    - ${{ inputs.repository }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,14 @@ REPO="${2:?Missing repo input}"
 BRANCH="${3:?Missing branch input}"
 EMPTY="${4:-false}"
 read -r -a FILE_PATTERNS <<<"${5:?Missing file_pattern input}"
+REPOSITORY="${6:-.}"
 
-git config --global --add safe.directory "$GITHUB_WORKSPACE"
+REPOSITORY_PATH="$GITHUB_WORKSPACE/$REPOSITORY"
+echo "Repository path: $REPOSITORY_PATH"
+
+git config --global --add safe.directory "$REPOSITORY_PATH"
+
+cd "$REPOSITORY_PATH"
 
 adds=()
 deletes=()

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -7,7 +7,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 # export GHCOMMIT_STUB_DEBUG=/dev/tty
 
 setup() {
-  export GITHUB_WORKSPACE=/tmp
+  export GITHUB_WORKSPACE="$BATS_TEST_DIRNAME/.."
   #export DEBUG=1
 }
 
@@ -25,7 +25,7 @@ setup() {
   # to modify and prevent cat from removing the leading space on lines/entries since that is a part
   # of the git status output.
   stub git \
-    "config --global --add safe.directory $GITHUB_WORKSPACE : echo stubbed" \
+    "config --global --add safe.directory $GITHUB_WORKSPACE/. : echo stubbed" \
     "status -s --porcelain=v1 -z -- . : cat ./tests/fixtures/git-status.out-1 | tr '\n' '\0'"
 
   stub ghcommit \
@@ -46,7 +46,7 @@ setup() {
   local file_pattern='.'
 
   stub git \
-    "config --global --add safe.directory $GITHUB_WORKSPACE : echo stubbed" \
+    "config --global --add safe.directory $GITHUB_WORKSPACE/. : echo stubbed" \
     "status -s --porcelain=v1 -z -- . : echo"
 
   run ./entrypoint.sh "$commit_message" "$repo" "$branch" "$empty" "$file_pattern"
@@ -64,7 +64,7 @@ setup() {
   export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github-output"
 
   stub git \
-    "config --global --add safe.directory $GITHUB_WORKSPACE : echo stubbed" \
+    "config --global --add safe.directory $GITHUB_WORKSPACE/. : echo stubbed" \
     "status -s --porcelain=v1 -z -- . : echo"
 
   stub ghcommit \
@@ -77,6 +77,32 @@ setup() {
   assert_file_contains "$GITHUB_OUTPUT" "commit-url=https://localhost/foo"
 }
 
+@test "switches to repository subdirectory when repository input is set" {
+  local commit_message='msg'
+  local repo='org/repo'
+  local branch='main'
+  local empty='false'
+  local file_pattern='.'
+  local repository='tests/fixtures'
+
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github-output"
+
+  stub git \
+    "config --global --add safe.directory $GITHUB_WORKSPACE/tests/fixtures : echo stubbed" \
+    "status -s --porcelain=v1 -z -- . : echo"
+
+  stub ghcommit \
+    '-b main -r org/repo -m msg --empty : echo Success. New commit: https://localhost/sub'
+
+  # Use --empty to force ghcommit to run even without staged changes, so we can
+  # verify the working directory change took effect (otherwise the stub for
+  # ghcommit would not be exercised).
+  run ./entrypoint.sh "$commit_message" "$repo" "$branch" "true" "$file_pattern" "$repository"
+  assert_success
+  assert_output --partial "Repository path: $GITHUB_WORKSPACE/tests/fixtures"
+  assert_output --partial "Success"
+}
+
 @test "handles untracked files" {
   local commit_message='msg'
   local repo='org/repo'
@@ -87,7 +113,7 @@ setup() {
   export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github-output"
 
   stub git \
-    "config --global --add safe.directory $GITHUB_WORKSPACE : echo stubbed" \
+    "config --global --add safe.directory $GITHUB_WORKSPACE/. : echo stubbed" \
     "status -s --porcelain=v1 -z -- . : cat ./tests/fixtures/git-status.out-2 | tr '\n' '\0'"
 
   stub ghcommit \


### PR DESCRIPTION
Add an optional `repository` input that points to a relative path under $GITHUB_WORKSPACE for the git repository to operate on. Defaults to `.` (the workspace root). The entrypoint adds the resolved path to safe.directory and cd's into it before running git status / ghcommit.

This mirrors the behaviour of stefanzweifel/git-auto-commit-action and enables using the action on repositories checked out into a subdirectory of the workflow workspace.