### PR TITLE
ci: pin renovate npm package in validate workflow

### DIFF
--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   LOG_LEVEL: debug
+  RENOVATE_VERSION: "44.11.4" # renovate: datasource=npm depName=renovate
 
 jobs:
   renovate-config-validator:
@@ -18,4 +19,4 @@ jobs:
         with:
           node-version: lts/*
 
-      - run: npx -p renovate renovate-config-validator renovate.json
+      - run: npx --yes --ignore-scripts -p "renovate@${RENOVATE_VERSION}" -- renovate-config-validator renovate.json


### PR DESCRIPTION
**Problem:**

Doing security hardening in light of recent npm
supply-chain issues. The renovate config validator
was resolving an unpinned package at CI time.

**Solution:**

Pin renovate via `RENOVATE_VERSION` (currently
44.11.4) with a Renovate datasource comment so
updates stay reviewable. Invoke the pinned package
with `npx --yes --ignore-scripts`.

---
_Security Impact:_

CI installs of renovate are pinned and skip
lifecycle scripts.

---
_Testing:_ N/A - it's part of CI
